### PR TITLE
Simplify cache dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
         "ext-json": "*",
         "psr/cache": "^1.0",
         "psr/log": "^1.0",
-        "cache/cache": "^1|^0.4",
         "doctrine/inflector": "~1.3",
         "weew/helpers-array": "^1.3",
         "psr/http-client": "^1.0",
-        "psr/http-factory": "^1.0"
+        "psr/http-factory": "^1.0",
+        "cache/array-adapter": "^1.0"
     },
     "require-dev": {
         "codeception/codeception": "^2.2",


### PR DESCRIPTION
This Vault PHP client only uses the array cache adapter, so
there is no need to require the complete `cache/cache` package.

This change was prompted when trying to require the
`contentful/contentful:6.0.3` package into a project where
`csharpru/vault-php` was already installed. Since the Contentful
package requires the void cache adapter, it cannot be installed
in a project with the complete cache/cache package already
installed. This is because `cache/cache` conflicts with all of the
individual `cache/*` packages (since it already contains all of them).

Checked that all tests pass.