### PR TITLE
Removing Reflector dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,12 @@ php:
   - '7.4'
 #  - nightly
 sudo: required
+before_install:
+  - sudo apt-get install jq
+  - curl -LSs "$(curl -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({name, browser_download_url} | select(.name | endswith(".jar"))) | .[0].browser_download_url')" -o codacy-coverage-reporter-assembly.jar
 install:
   - composer install -n
 script:
   - php vendor/bin/codecept run --coverage-xml
-after_script:
-  - php vendor/bin/codacycoverage clover tests/_output/coverage.xml
+after_success:
+  - java -jar codacy-coverage-reporter-assembly.jar report -l PHP -r tests/_output/coverage.xml

--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,14 @@
         "ext-json": "*",
         "psr/cache": "^1.0",
         "psr/log": "^1.0",
-        "doctrine/inflector": "~1.3",
         "weew/helpers-array": "^1.3",
         "psr/http-client": "^1.0",
-        "psr/http-factory": "^1.0"
+        "psr/http-factory": "^1.0",
+        "alextartan/guzzle-psr18-adapter": "^1.2"
     },
     "require-dev": {
         "codeception/codeception": "^2.2",
         "php-vcr/php-vcr": "dev-issues/289 as 1.4.5",
-        "alextartan/guzzle-psr18-adapter": "^1.2",
         "laminas/laminas-diactoros": "^2.3",
         "cache/array-adapter": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
         "psr/log": "^1.0",
         "weew/helpers-array": "^1.3",
         "psr/http-client": "^1.0",
-        "psr/http-factory": "^1.0",
-        "alextartan/guzzle-psr18-adapter": "^1.2"
+        "psr/http-factory": "^1.0"
     },
     "require-dev": {
         "codeception/codeception": "^2.2",
         "php-vcr/php-vcr": "dev-issues/289 as 1.4.5",
+        "alextartan/guzzle-psr18-adapter": "^1.2",
         "laminas/laminas-diactoros": "^2.3",
         "cache/array-adapter": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "ext-json": "*",
         "psr/cache": "^1.0",
         "psr/log": "^1.0",
-        "cache/cache": "^1|^0.4",
         "doctrine/inflector": "~1.3",
         "weew/helpers-array": "^1.3",
         "psr/http-client": "^1.0",
@@ -32,8 +31,11 @@
     "require-dev": {
         "codeception/codeception": "^2.2",
         "php-vcr/php-vcr": "dev-issues/289 as 1.4.5",
-        "codacy/coverage": "^1.1",
         "alextartan/guzzle-psr18-adapter": "^1.2",
-        "zendframework/zend-diactoros": "^2.0"
+        "laminas/laminas-diactoros": "^2.3",
+        "cache/array-adapter": "^1.0"
+    },
+    "suggest": {
+        "cache/array-adapter": "For usage with CachedClient class"
     }
 }

--- a/src/AuthenticationStrategies/AbstractPathAuthenticationStrategy.php
+++ b/src/AuthenticationStrategies/AbstractPathAuthenticationStrategy.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Vault\AuthenticationStrategies;
+
+use Psr\Http\Client\ClientExceptionInterface;
+use Vault\Exceptions\AuthenticationException;
+use Vault\ResponseModels\Auth;
+
+/**
+ * Class AbstractUserPassAuthenticationStrategy
+ *
+ * @package Vault\AuthenticationStrategies
+ */
+abstract class AbstractPathAuthenticationStrategy extends AbstractAuthenticationStrategy
+{
+    /**
+     * @var string
+     */
+    protected $username;
+
+    /**
+     * @var string
+     */
+    protected $password;
+
+    /**
+     * @var string
+     */
+    protected $methodPathSegment;
+
+    /**
+     * AbstractUserPassAuthenticationStrategy constructor.
+     *
+     * @param string $username The Username used to authenticate to Vault
+     * @param string $password The Password used to authenticate to Vault
+     */
+    public function __construct($username, $password)
+    {
+        $this->username = $username;
+        $this->password = $password;
+    }
+
+    /**
+     * Returns auth for further interactions with Vault.
+     *
+     * @return Auth
+     * @throws AuthenticationException
+     * @throws ClientExceptionInterface
+     */
+    public function authenticate(): Auth
+    {
+        if (!$this->methodPathSegment) {
+            throw new AuthenticationException('methodPathSegment must be set before usage');
+        }
+
+        $response = $this->client->write(
+            sprintf('/auth/%s/login/%s', $this->methodPathSegment, $this->username),
+            ['password' => $this->password]
+        );
+
+        return $response->getAuth();
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethodPathSegment(): string
+    {
+        return $this->methodPathSegment;
+    }
+
+    /**
+     * @param string $methodPathSegment
+     *
+     * @return static
+     */
+    public function setMethodPathSegment(string $methodPathSegment)
+    {
+        $this->methodPathSegment = $methodPathSegment;
+
+        return $this;
+    }
+}

--- a/src/AuthenticationStrategies/LdapAuthenticationStrategy.php
+++ b/src/AuthenticationStrategies/LdapAuthenticationStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Vault\AuthenticationStrategies;
+
+/**
+ * Class LdapAuthenticationStrategy
+ *
+ * @package Vault\AuthenticationStrategy
+ */
+class LdapAuthenticationStrategy extends AbstractPathAuthenticationStrategy
+{
+    /**
+     * @var string
+     */
+    protected $methodPathSegment = 'ldap';
+}

--- a/src/AuthenticationStrategies/OktaAuthenticationStrategy.php
+++ b/src/AuthenticationStrategies/OktaAuthenticationStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Vault\AuthenticationStrategies;
+
+/**
+ * Class OktaAuthenticationStrategy
+ *
+ * @package Vault\AuthenticationStrategy
+ */
+class OktaAuthenticationStrategy extends AbstractPathAuthenticationStrategy
+{
+    /**
+     * @var string
+     */
+    protected $methodPathSegment = 'okta';
+}

--- a/src/AuthenticationStrategies/RadiusAuthenticationStrategy.php
+++ b/src/AuthenticationStrategies/RadiusAuthenticationStrategy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Vault\AuthenticationStrategies;
+
+/**
+ * Class RadiusAuthenticationStrategy
+ *
+ * @package Vault\AuthenticationStrategy
+ */
+class RadiusAuthenticationStrategy extends AbstractPathAuthenticationStrategy
+{
+    /**
+     * @var string
+     */
+    protected $methodPathSegment = 'radius';
+}

--- a/src/AuthenticationStrategies/UserPassAuthenticationStrategy.php
+++ b/src/AuthenticationStrategies/UserPassAuthenticationStrategy.php
@@ -2,51 +2,15 @@
 
 namespace Vault\AuthenticationStrategies;
 
-use Psr\Http\Client\ClientExceptionInterface;
-use Vault\ResponseModels\Auth;
-
 /**
  * Class UserPassAuthenticationStrategy
  *
  * @package Vault\AuthenticationStrategy
  */
-class UserPassAuthenticationStrategy extends AbstractAuthenticationStrategy
+class UserPassAuthenticationStrategy extends AbstractPathAuthenticationStrategy
 {
     /**
      * @var string
      */
-    protected $username;
-
-    /**
-     * @var string
-     */
-    protected $password;
-
-    /**
-     * UserPassAuthenticationStrategy constructor.
-     *
-     * @param string $username
-     * @param string $password
-     */
-    public function __construct($username, $password)
-    {
-        $this->username = $username;
-        $this->password = $password;
-    }
-
-    /**
-     * Returns auth for further interactions with Vault.
-     *
-     * @return Auth
-     * @throws ClientExceptionInterface
-     */
-    public function authenticate(): Auth
-    {
-        $response = $this->client->write(
-            sprintf('/auth/userpass/login/%s', $this->username),
-            ['password' => $this->password]
-        );
-
-        return $response->getAuth();
-    }
+    protected $methodPathSegment = 'userpass';
 }

--- a/src/Helpers/ModelHelper.php
+++ b/src/Helpers/ModelHelper.php
@@ -2,8 +2,6 @@
 
 namespace Vault\Helpers;
 
-use Doctrine\Common\Inflector\Inflector;
-
 /**
  * Class Model
  *
@@ -26,9 +24,16 @@ class ModelHelper
                 $value = self::camelize($value, $recursive);
             }
 
-            $return[Inflector::camelize($key)] = $value;
+            $return[self::camelizeString($key)] = $value;
         }
 
         return $return;
+    }
+
+    private static function camelizeString(string $data): string
+    {
+        $camelizedString = str_replace([' ', '_', '-'], '', ucwords($data, ' _-'));
+
+        return lcfirst($camelizedString);
     }
 }


### PR DESCRIPTION
Hi!
I think it is excess dependency. Besides, it is deprecated package, and it makes some problem in case, when i want to use your lib in app with new Reflector. 

Also, i moved alextartan/guzzle-psr18-adapter to require block, cause if you want to use Client for vault, you must have this Adapter. And i dont understand, why dont we include it to require block?