### PR TITLE
Fix null auth

### DIFF
--- a/src/AuthenticationStrategies/AppRoleAuthenticationStrategy.php
+++ b/src/AuthenticationStrategies/AppRoleAuthenticationStrategy.php
@@ -47,7 +47,7 @@ class AppRoleAuthenticationStrategy extends AbstractAuthenticationStrategy
      * @return Auth
      * @throws ClientExceptionInterface
      */
-    public function authenticate(): Auth
+    public function authenticate(): ?Auth
     {
         $response = $this->client->write(
             '/auth/' . $this->name . '/login',

--- a/src/AuthenticationStrategies/AuthenticationStrategy.php
+++ b/src/AuthenticationStrategies/AuthenticationStrategy.php
@@ -17,7 +17,7 @@ interface AuthenticationStrategy
      *
      * @return Auth
      */
-    public function authenticate(): Auth;
+    public function authenticate(): ?Auth;
 
     /**
      * @return Client

--- a/src/AuthenticationStrategies/TokenAuthenticationStrategy.php
+++ b/src/AuthenticationStrategies/TokenAuthenticationStrategy.php
@@ -31,7 +31,7 @@ class TokenAuthenticationStrategy extends AbstractAuthenticationStrategy
      *
      * @return Auth
      */
-    public function authenticate(): Auth
+    public function authenticate(): ?Auth
     {
         return new Auth(['clientToken' => $this->token]);
     }


### PR DESCRIPTION
When auth creditinal is wrong - response return null (Response::getAuth() ?Auth)
Result:
```
 Declaration of Vault\AuthenticationStrategies\AppRoleAuthenticationStrategy::authenticate(): ?Vault\ResponseModels\Auth must be compatible with Vault\AuthenticationStrategies\AuthenticationStrat
egy::authenticate(): Vault\ResponseModels\Auth
```
