### PR TITLE
Update namepsace of laminas-diactoros

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,13 +19,13 @@ Quick start
 
     <?php
 
+    use Laminas\Diactoros\RequestFactory;
+    use Laminas\Diactoros\StreamFactory;
+    use Laminas\Diactoros\Uri;
     use Vault\AuthenticationStrategies\AppRoleAuthenticationStrategy;
     use Vault\AuthenticationStrategies\UserPassAuthenticationStrategy;
     use Vault\AuthenticationStrategies\TokenAuthenticationStrategy;
     use Vault\Client;
-    use Zend\Diactoros\RequestFactory;
-    use Zend\Diactoros\StreamFactory;
-    use Zend\Diactoros\Uri;
 
     // Creating the client
     $client = new Client(
@@ -62,11 +62,11 @@ Fetching a secret
 
     <?php
 
+    use Laminas\Diactoros\RequestFactory;
+    use Laminas\Diactoros\StreamFactory;
+    use Laminas\Diactoros\Uri;
     use Vault\AuthenticationStrategies\TokenAuthenticationStrategy;
     use Vault\Client;
-    use Zend\Diactoros\RequestFactory;
-    use Zend\Diactoros\StreamFactory;
-    use Zend\Diactoros\Uri;
 
     // Creating the client
     $client = new Client(

--- a/tests/unit/AuthenticationStrategies/AppRoleAuthenticationStrategyTest.php
+++ b/tests/unit/AuthenticationStrategies/AppRoleAuthenticationStrategyTest.php
@@ -1,13 +1,13 @@
 <?php
 
 use Codeception\Test\Unit;
+use Laminas\Diactoros\RequestFactory;
+use Laminas\Diactoros\StreamFactory;
+use Laminas\Diactoros\Uri;
 use Psr\Http\Client\ClientExceptionInterface;
 use Vault\AuthenticationStrategies\AppRoleAuthenticationStrategy;
 use Vault\Client;
 use VCR\VCR;
-use Zend\Diactoros\RequestFactory;
-use Zend\Diactoros\StreamFactory;
-use Zend\Diactoros\Uri;
 
 class AppRoleAuthenticationStrategyTest extends Unit
 {

--- a/tests/unit/AuthenticationStrategies/TokenAuthenticationStrategyTest.php
+++ b/tests/unit/AuthenticationStrategies/TokenAuthenticationStrategyTest.php
@@ -1,14 +1,14 @@
 <?php
 
 use Codeception\Test\Unit;
+use Laminas\Diactoros\RequestFactory;
+use Laminas\Diactoros\StreamFactory;
+use Laminas\Diactoros\Uri;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Log\NullLogger;
 use Vault\AuthenticationStrategies\TokenAuthenticationStrategy;
 use Vault\Client;
 use VCR\VCR;
-use Zend\Diactoros\RequestFactory;
-use Zend\Diactoros\StreamFactory;
-use Zend\Diactoros\Uri;
 
 class TokenAuthenticationStrategyTest extends Unit
 {

--- a/tests/unit/CachedClientTest.php
+++ b/tests/unit/CachedClientTest.php
@@ -3,14 +3,14 @@
 use AlexTartan\GuzzlePsr18Adapter\Client;
 use Cache\Adapter\PHPArray\ArrayCachePool;
 use Codeception\Test\Unit;
+use Laminas\Diactoros\RequestFactory;
+use Laminas\Diactoros\StreamFactory;
+use Laminas\Diactoros\Uri;
 use Psr\Http\Client\ClientExceptionInterface;
 use Vault\AuthenticationStrategies\UserPassAuthenticationStrategy;
 use Vault\CachedClient;
 use Vault\ResponseModels\Response;
 use VCR\VCR;
-use Zend\Diactoros\RequestFactory;
-use Zend\Diactoros\StreamFactory;
-use Zend\Diactoros\Uri;
 
 class CachedClientTest extends Unit
 {

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -3,6 +3,9 @@
 use Cache\Adapter\PHPArray\ArrayCachePool;
 use Codeception\Test\Unit;
 use Codeception\Util\Stub;
+use Laminas\Diactoros\RequestFactory;
+use Laminas\Diactoros\StreamFactory;
+use Laminas\Diactoros\Uri;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
@@ -15,9 +18,6 @@ use Vault\Exceptions\RuntimeException;
 use Vault\Models\Token;
 use Vault\ResponseModels\Auth;
 use VCR\VCR;
-use Zend\Diactoros\RequestFactory;
-use Zend\Diactoros\StreamFactory;
-use Zend\Diactoros\Uri;
 
 class ClientTest extends Unit
 {


### PR DESCRIPTION
This PR provides changes that were introduced in the renaming of Zend to Laminas in the used package `laminas/laminas-diactoros`. This affects tests and documentation only.