### PR TITLE
Add secrets engines abstraction

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -25,9 +25,9 @@ use Vault\ResponseModels\Response;
  */
 abstract class BaseClient implements LoggerAwareInterface
 {
-    public const VERSION_1 = 'v1';
-
     use LoggerAwareTrait;
+    
+    public const VERSION_1 = 'v1';
 
     /**
      * @var string
@@ -40,7 +40,7 @@ abstract class BaseClient implements LoggerAwareInterface
     protected $token;
 
     /**
-     * @var Namespace
+     * @var string
      */
     protected $namespace;
 
@@ -116,9 +116,10 @@ abstract class BaseClient implements LoggerAwareInterface
      */
     public function send(string $method, string $path, string $body = ''): ResponseInterface
     {
+        $method = strtoupper($method);
         $headers = [
             'User-Agent' => 'VaultPHP/1.0.0',
-            'Content-Type' => 'application/json',
+            'Content-Type' => ($method === 'PATCH' ? 'application/merge-patch+json' : 'application/json'),
         ];
 
         if ($this->token) {
@@ -134,7 +135,7 @@ abstract class BaseClient implements LoggerAwareInterface
             $this->baseUri = $this->baseUri->withQuery($query);
         }
 
-        $request = $this->requestFactory->createRequest(strtoupper($method), $this->baseUri->withPath($path));
+        $request = $this->requestFactory->createRequest($method, $this->baseUri->withPath($path));
 
         foreach ($headers as $name => $value) {
             $request = $request->withHeader($name, $value);
@@ -309,7 +310,7 @@ abstract class BaseClient implements LoggerAwareInterface
     }
 
     /**
-     * @return Namespace
+     * @return string
      */
     public function getNamespace(): string
     {
@@ -317,7 +318,7 @@ abstract class BaseClient implements LoggerAwareInterface
     }
 
     /**
-     * @param String $namespace
+     * @param string $namespace
      *
      * @return $this
      */

--- a/src/BaseObject.php
+++ b/src/BaseObject.php
@@ -2,15 +2,16 @@
 
 namespace Vault;
 
-use RuntimeException;
+use Vault\Exceptions\RuntimeException;
 use Vault\Helpers\ArrayHelper;
+use Vault\Helpers\ModelHelper;
 
 /**
- * Class Object
+ * Class BaseObject
  *
  * @package Vault
  */
-class BaseObject
+class BaseObject implements \JsonSerializable
 {
     /**
      * Object constructor.
@@ -192,5 +193,15 @@ class BaseObject
         }
 
         return $result;
+    }
+
+    /**
+     * @return array
+     * 
+     * @throws RuntimeException
+     */
+    public function jsonSerialize(): array
+    {
+        return ModelHelper::snakelize($this->toArray(), false);
     }
 }

--- a/src/Builders/KeyValueVersion1/ListResponseBuilder.php
+++ b/src/Builders/KeyValueVersion1/ListResponseBuilder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Vault\Builders\KeyValueVersion1;
+
+use Vault\Helpers\ModelHelper;
+use Vault\ResponseModels\KeyValueVersion1\ListResponse;
+use Vault\ResponseModels\Response;
+
+/**
+ * Class ListResponseBuilder
+ *
+ * @package Vault\Builder\KeyValueVersion1
+ */
+class ListResponseBuilder
+{
+    /**
+     * @param Response $response
+     *
+     * @return ListResponse
+     */
+    public static function build(Response $response): ListResponse
+    {
+        $data = $response->getData();
+        
+        return new ListResponse(ModelHelper::camelize($data, false));
+    }
+}

--- a/src/Builders/KeyValueVersion2/ListResponseBuilder.php
+++ b/src/Builders/KeyValueVersion2/ListResponseBuilder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Vault\Builders\KeyValueVersion2;
+
+use Vault\Helpers\ModelHelper;
+use Vault\ResponseModels\KeyValueVersion2\ListResponse;
+use Vault\ResponseModels\Response;
+
+/**
+ * Class ListResponseBuilder
+ *
+ * @package Vault\Builder\KeyValueVersion2
+ */
+class ListResponseBuilder
+{
+    /**
+     * @param Response $response
+     *
+     * @return ListResponse
+     */
+    public static function build(Response $response): ListResponse
+    {
+        $data = $response->getData();
+        
+        return new ListResponse(ModelHelper::camelize($data, false));
+    }
+}

--- a/src/Builders/KeyValueVersion2/ReadConfigurationResponseBuilder.php
+++ b/src/Builders/KeyValueVersion2/ReadConfigurationResponseBuilder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Vault\Builders\KeyValueVersion2;
+
+use Vault\Helpers\ModelHelper;
+use Vault\Models\KeyValueVersion2\Configuration;
+use Vault\ResponseModels\Response;
+
+/**
+ * Class ReadConfigurationResponseBuilder
+ *
+ * @package Vault\Builder\KeyValueVersion2
+ */
+class ReadConfigurationResponseBuilder
+{
+    /**
+     * @param Response $response
+     *
+     * @return Configuration
+     */
+    public static function build(Response $response): Configuration
+    {
+        $data = $response->getData();
+        
+        return new Configuration(ModelHelper::camelize($data, false));
+    }
+}

--- a/src/Builders/KeyValueVersion2/ReadMetadataResponseBuilder.php
+++ b/src/Builders/KeyValueVersion2/ReadMetadataResponseBuilder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Vault\Builders\KeyValueVersion2;
+
+use Vault\Helpers\ModelHelper;
+use Vault\ResponseModels\KeyValueVersion2\ReadMetadataResponse;
+use Vault\ResponseModels\KeyValueVersion2\VersionMetadata;
+use Vault\ResponseModels\Response;
+
+/**
+ * Class ReadMetadataResponseBuilder
+ *
+ * @package Vault\Builder\KeyValueVersion2
+ */
+class ReadMetadataResponseBuilder
+{
+    /**
+     * @param Response $response
+     *
+     * @return ReadMetadataResponse
+     */
+    public static function build(Response $response): ReadMetadataResponse
+    {
+        $data = $response->getData();
+        
+        $versions = [];
+        foreach ($data['versions'] as $versionNumber => $versionData) {
+            $versionData['custom_metadata'] = $data['custom_metadata'] ?? null;
+            $versionData['version'] = $versionNumber;
+            $versions[$versionNumber] = new VersionMetadata(ModelHelper::camelize($versionData, false));
+        }
+        $data['versions'] = $versions;
+        
+        return new ReadMetadataResponse(ModelHelper::camelize($data, false));
+    }
+}

--- a/src/Builders/KeyValueVersion2/ReadResponseBuilder.php
+++ b/src/Builders/KeyValueVersion2/ReadResponseBuilder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Vault\Builders\KeyValueVersion2;
+
+use Vault\Helpers\ModelHelper;
+use Vault\ResponseModels\KeyValueVersion2\ReadResponse;
+use Vault\ResponseModels\KeyValueVersion2\VersionMetadata;
+use Vault\ResponseModels\Response;
+
+/**
+ * Class ReadResponseBuilder
+ *
+ * @package Vault\Builder\KeyValueVersion2
+ */
+class ReadResponseBuilder
+{
+    /**
+     * @param Response $response
+     *
+     * @return ReadResponse
+     */
+    public static function build(Response $response): ReadResponse
+    {
+        $data = $response->getData();
+        
+        $data['metadata'] = new VersionMetadata(ModelHelper::camelize($data['metadata'], false));
+        
+        return new ReadResponse($data);
+    }
+}

--- a/src/Builders/KeyValueVersion2/ReadSubkeysResponseBuilder.php
+++ b/src/Builders/KeyValueVersion2/ReadSubkeysResponseBuilder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Vault\Builders\KeyValueVersion2;
+
+use Vault\Helpers\ModelHelper;
+use Vault\ResponseModels\KeyValueVersion2\ReadSubkeysResponse;
+use Vault\ResponseModels\KeyValueVersion2\VersionMetadata;
+use Vault\ResponseModels\Response;
+
+/**
+ * Class ReadSubkeysResponseBuilder
+ *
+ * @package Vault\Builder\KeyValueVersion2
+ */
+class ReadSubkeysResponseBuilder
+{
+    /**
+     * @param Response $response
+     *
+     * @return ReadSubkeysResponse
+     */
+    public static function build(Response $response): ReadSubkeysResponse
+    {
+        $data = $response->getData();
+        
+        $data['metadata'] = new VersionMetadata(ModelHelper::camelize($data['metadata'], false));
+        
+        return new ReadSubkeysResponse($data);
+    }
+}

--- a/src/Builders/KeyValueVersion2/VersionMetadataResponseBuilder.php
+++ b/src/Builders/KeyValueVersion2/VersionMetadataResponseBuilder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Vault\Builders\KeyValueVersion2;
+
+use Vault\Helpers\ModelHelper;
+use Vault\ResponseModels\KeyValueVersion2\VersionMetadata;
+use Vault\ResponseModels\Response;
+
+/**
+ * Class VersionMetadataResponseBuilder
+ *
+ * @package Vault\Builder\KeyValueVersion2
+ */
+class VersionMetadataResponseBuilder
+{
+    /**
+     * @param Response $response
+     *
+     * @return VersionMetadata
+     */
+    public static function build(Response $response): VersionMetadata
+    {
+        $data = $response->getData();
+        
+        return new VersionMetadata(ModelHelper::camelize($data, false));
+    }
+}

--- a/src/Helpers/ModelHelper.php
+++ b/src/Helpers/ModelHelper.php
@@ -2,8 +2,10 @@
 
 namespace Vault\Helpers;
 
+use Vault\Exceptions\RuntimeException;
+
 /**
- * Class Model
+ * Class ModelHelper
  *
  * @package Vault\Helper
  */
@@ -35,5 +37,42 @@ class ModelHelper
         $camelizedString = str_replace([' ', '_', '-'], '', ucwords($data, ' _-'));
 
         return lcfirst($camelizedString);
+    }
+
+    /**
+     * @param array $data
+     * @param bool $recursive
+     *
+     * @return array
+     * 
+     * @throws RuntimeException
+     */
+    public static function snakelize(array $data, $recursive = true): array
+    {
+        $return = [];
+
+        foreach ($data as $key => $value) {
+            if (is_array($value) && $recursive) {
+                $value = self::snakelize($value, $recursive);
+            }
+
+            $return[self::snakelizeString($key)] = $value;
+        }
+
+        return $return;
+    }
+
+    private static function snakelizeString(string $data): string
+    {
+        $snakelizedString = preg_replace('~(?<=\\w)([A-Z])~u', '_$1', $data);
+
+        if ($snakelizedString === null) {
+            throw new RuntimeException(sprintf(
+                'preg_replace returned null when trying to snakelize value "%s"',
+                $data
+            ));
+        }
+
+        return mb_strtolower($snakelizedString);
     }
 }

--- a/src/Models/KeyValueVersion2/Configuration.php
+++ b/src/Models/KeyValueVersion2/Configuration.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Vault\Models\KeyValueVersion2;
+
+use Vault\BaseObject;
+
+/**
+ * Class Configuration
+ *
+ * @package Vault\Models\KeyValueVersion2
+ */
+class Configuration extends BaseObject
+{
+    /**
+     * If true all keys will require the cas parameter to be set on all write requests
+     * 
+     * @var bool
+     */
+    protected $casRequired = false;
+
+    /**
+     * Specifies the length of time before a version is deleted. Accepts duration format strings
+     * 
+     * @var string
+     */
+    protected $deleteVersionAfter = '0s';
+
+    /**
+     * The number of versions to keep per key. When 0 is used or the value is unset, Vault will keep 10 versions
+     * 
+     * @var int
+     */
+    protected $maxVersions = 0;
+
+    /**
+     * Get {@see $casRequired cas_required}
+     * 
+     * @return bool
+     */
+    public function isCasRequired(): bool
+    {
+        return $this->casRequired;
+    }
+
+    /**
+     * Set {@see $casRequired cas_required}
+     * 
+     * @param bool $casRequired
+     * 
+     * @return $this
+     */
+    public function setCasRequired(bool $casRequired): self
+    {
+        $this->casRequired = $casRequired;
+
+        return $this;
+    }
+
+    /**
+     * Get {@see $deleteVersionAfter delete_version_after}
+     * 
+     * @return string
+     */
+    public function getDeleteVersionAfter(): string
+    {
+        return $this->deleteVersionAfter;
+    }
+
+    /**
+     * Set {@see $deleteVersionAfter delete_version_after}
+     * 
+     * @param string $deleteVersionAfter
+     * 
+     * @return $this
+     */
+    public function setDeleteVersionAfter(string $deleteVersionAfter): self
+    {
+        $this->deleteVersionAfter = $deleteVersionAfter;
+
+        return $this;
+    }
+
+    /**
+     * Get {@see $maxVersions max_versions}
+     * 
+     * @return int
+     */
+    public function getMaxVersions(): int
+    {
+        return $this->maxVersions;
+    }
+
+    /**
+     * Set {@see $maxVersions max_versions}
+     * 
+     * @param int $maxVersions
+     * 
+     * @return $this
+     */
+    public function setMaxVersions(int $maxVersions): self
+    {
+        $this->maxVersions = $maxVersions;
+
+        return $this;
+    }
+}

--- a/src/Models/KeyValueVersion2/SecretMetadata.php
+++ b/src/Models/KeyValueVersion2/SecretMetadata.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Vault\Models\KeyValueVersion2;
+
+/**
+ * Class SecretMetadata
+ *
+ * @package Vault\Models\KeyValueVersion2
+ */
+class SecretMetadata extends Configuration
+{
+    /**
+     * A map of arbitrary string to string valued user-provided metadata meant to describe the secret
+     * 
+     * @var array|null
+     */
+    protected $customMetadata;
+
+    /**
+     * Get {@see $customMetadata custom_metadata}
+     * 
+     * @return array|null
+     */
+    public function getCustomMetadata(): ?array
+    {
+        return $this->customMetadata;
+    }
+
+    /**
+     * Set {@see $customMetadata custom_metadata}
+     * 
+     * @param array|null $customMetadata
+     * 
+     * @return $this
+     */
+    public function setCustomMetadata(?array $customMetadata): self
+    {
+        $this->customMetadata = $customMetadata;
+
+        return $this;
+    }
+}

--- a/src/Models/KeyValueVersion2/WriteOptions.php
+++ b/src/Models/KeyValueVersion2/WriteOptions.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Vault\Models\KeyValueVersion2;
+
+use Vault\BaseObject;
+
+/**
+ * Class WriteOptions
+ *
+ * @package Vault\Models\KeyValueVersion2
+ */
+class WriteOptions extends BaseObject
+{
+    /**
+     * This flag is required if cas_required is set to true on either the secret or the engine's config. If not set the write will be allowed. In order for a write to be successful, cas must be set to the current version of the secret. If set to 0 a write will only be allowed if the key doesn't exist as unset keys do not have any version information.
+     * 
+     * @var int|null
+     */
+    protected $cas;
+
+    /**
+     * Get {@see $cas cas}
+     * 
+     * @return int|null
+     */
+    public function getCas(): ?int
+    {
+        return $this->cas;
+    }
+
+    /**
+     * Set {@see $cas cas}
+     * 
+     * @param int $cas
+     * 
+     * @return $this
+     */
+    public function setCas(?int $cas): self
+    {
+        $this->cas = $cas;
+
+        return $this;
+    }
+}

--- a/src/ResponseModels/KeyValueVersion1/ListResponse.php
+++ b/src/ResponseModels/KeyValueVersion1/ListResponse.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Vault\ResponseModels\KeyValueVersion1;
+
+use Vault\BaseObject;
+
+/**
+ * Class ListResponse
+ *
+ * @package Vault\Model\KeyValueVersion1
+ */
+class ListResponse extends BaseObject
+{
+    /**
+     * @var array
+     */
+    protected $keys;
+    
+    /**
+     * @return array
+     */
+    public function getKeys(): array
+    {
+        return $this->keys;
+    }
+}

--- a/src/ResponseModels/KeyValueVersion2/ListResponse.php
+++ b/src/ResponseModels/KeyValueVersion2/ListResponse.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Vault\ResponseModels\KeyValueVersion2;
+
+use Vault\BaseObject;
+
+/**
+ * Class ListResponse
+ *
+ * @package Vault\Model\KeyValueVersion2
+ */
+class ListResponse extends BaseObject
+{
+    /**
+     * @var array
+     */
+    protected $keys;
+    
+    /**
+     * @return array
+     */
+    public function getKeys(): array
+    {
+        return $this->keys;
+    }
+}

--- a/src/ResponseModels/KeyValueVersion2/ReadMetadataResponse.php
+++ b/src/ResponseModels/KeyValueVersion2/ReadMetadataResponse.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Vault\ResponseModels\KeyValueVersion2;
+
+use Vault\Models\KeyValueVersion2\SecretMetadata;
+
+/**
+ * Class ReadMetadataResponse
+ *
+ * @package Vault\Model\KeyValueVersion2
+ */
+class ReadMetadataResponse extends SecretMetadata
+{
+    /**
+     * @var string
+     */
+    protected $createdTime;
+
+    /**
+     * @var int
+     */
+    protected $currentVersion;
+
+    /**
+     * @var int
+     */
+    protected $oldestVersion;
+
+    /**
+     * @var string|null
+     */
+    protected $updatedTime;
+
+    /**
+     * @var VersionMetadata[]
+     */
+    protected $versions = [];
+
+    /**
+	 * @return string
+	 */
+	public function getCreatedTime(): string
+    {
+		return $this->createdTime;
+	}
+
+    /**
+	 * @return int
+	 */
+	public function getCurrentVersion(): int
+    {
+		return $this->currentVersion;
+	}
+
+    /**
+	 * @return int
+	 */
+	public function getOldestVersion(): int
+    {
+		return $this->oldestVersion;
+	}
+
+    /**
+	 * @return string|null
+	 */
+	public function getUpdatedTime(): ?string
+    {
+		return $this->updatedTime;
+	}
+
+    /**
+     * @return VersionMetadata[]
+     */
+    public function getVersions(): array
+    {
+        return $this->versions;
+    }
+}

--- a/src/ResponseModels/KeyValueVersion2/ReadMetadataResponse.php
+++ b/src/ResponseModels/KeyValueVersion2/ReadMetadataResponse.php
@@ -37,36 +37,36 @@ class ReadMetadataResponse extends SecretMetadata
     protected $versions = [];
 
     /**
-	 * @return string
-	 */
-	public function getCreatedTime(): string
+     * @return string
+     */
+    public function getCreatedTime(): string
     {
-		return $this->createdTime;
-	}
+        return $this->createdTime;
+    }
 
     /**
-	 * @return int
-	 */
-	public function getCurrentVersion(): int
+     * @return int
+     */
+    public function getCurrentVersion(): int
     {
-		return $this->currentVersion;
-	}
+        return $this->currentVersion;
+    }
 
     /**
-	 * @return int
-	 */
-	public function getOldestVersion(): int
+     * @return int
+     */
+    public function getOldestVersion(): int
     {
-		return $this->oldestVersion;
-	}
+        return $this->oldestVersion;
+    }
 
     /**
-	 * @return string|null
-	 */
-	public function getUpdatedTime(): ?string
+     * @return string|null
+     */
+    public function getUpdatedTime(): ?string
     {
-		return $this->updatedTime;
-	}
+        return $this->updatedTime;
+    }
 
     /**
      * @return VersionMetadata[]

--- a/src/ResponseModels/KeyValueVersion2/ReadResponse.php
+++ b/src/ResponseModels/KeyValueVersion2/ReadResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Vault\ResponseModels\KeyValueVersion2;
+
+use Vault\BaseObject;
+use Vault\ResponseModels\KeyValueVersion2\Traits\MetadataTrait;
+
+/**
+ * Class ReadResponse
+ *
+ * @package Vault\Model\KeyValueVersion2
+ */
+class ReadResponse extends BaseObject
+{
+    use MetadataTrait;
+
+    /**
+     * @var array
+     */
+    protected $data = [];
+    
+    /**
+     * @return array
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/ResponseModels/KeyValueVersion2/ReadSubkeysResponse.php
+++ b/src/ResponseModels/KeyValueVersion2/ReadSubkeysResponse.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Vault\ResponseModels\KeyValueVersion2;
+
+use Vault\BaseObject;
+use Vault\ResponseModels\KeyValueVersion2\Traits\MetadataTrait;
+
+/**
+ * Class ReadSubkeysResponse
+ *
+ * @package Vault\Model\KeyValueVersion2
+ */
+class ReadSubkeysResponse extends BaseObject
+{
+    use MetadataTrait;
+
+    /**
+     * @var array
+     */
+    protected $subkeys = [];
+    
+    /**
+     * @return array
+     */
+    public function getSubkeys(): array
+    {
+        return $this->subkeys;
+    }
+}

--- a/src/ResponseModels/KeyValueVersion2/Traits/MetadataTrait.php
+++ b/src/ResponseModels/KeyValueVersion2/Traits/MetadataTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Vault\ResponseModels\KeyValueVersion2\Traits;
+
+use Vault\ResponseModels\KeyValueVersion2\VersionMetadata;
+
+/**
+ * Class MetadataTrait
+ *
+ * @package Vault\Model\KeyValueVersion2
+ */
+trait MetadataTrait
+{
+    /**
+     * @var VersionMetadata
+     */
+    protected $metadata;
+    
+    /**
+     * @return VersionMetadata
+     */
+    public function getMetadata(): VersionMetadata
+    {
+        return $this->metadata;
+    }
+}

--- a/src/ResponseModels/KeyValueVersion2/VersionMetadata.php
+++ b/src/ResponseModels/KeyValueVersion2/VersionMetadata.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Vault\ResponseModels\KeyValueVersion2;
+
+use Vault\BaseObject;
+
+/**
+ * Class VersionMetadata
+ *
+ * @package Vault\Model\KeyValueVersion2
+ */
+class VersionMetadata extends BaseObject
+{
+    /**
+     * @var string
+     */
+    protected $createdTime;
+
+    /**
+     * @var array|null
+     */
+    protected $customMetadata;
+
+    /**
+     * @var string|null
+     */
+    protected $deletionTime;
+
+    /**
+     * @var bool
+     */
+    protected $destroyed;
+
+    /**
+     * @var int
+     */
+    protected $version;
+
+    /**
+     * @return string
+     */
+    public function getCreatedTime(): string
+    {
+        return $this->createdTime;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getCustomMetadata(): ?array
+    {
+        return $this->customMetadata;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDeletionTime(): ?string
+    {
+        return $this->deletionTime;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDestroyed(): bool
+    {
+        return $this->destroyed;
+    }
+
+    /**
+     * @return int
+     */
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+}

--- a/src/SecretsEngines/AbstractSecretsEngine.php
+++ b/src/SecretsEngines/AbstractSecretsEngine.php
@@ -22,6 +22,10 @@ abstract class AbstractSecretsEngine
      */
     protected $mount;
 
+    /**
+     * @param Client $client Authenticated Vault client
+     * @param string $mount Path to the secret engine (aka mount location)
+     */
     public function __construct(Client $client, string $mount)
     {
         $this->client = $client;
@@ -34,6 +38,11 @@ abstract class AbstractSecretsEngine
         $this->mount = $mount;
     }
 
+    /**
+     * @param string $path Path of the secret
+     *
+     * @return string
+     */
     public function buildPath(string $path): string
     {
         return sprintf('%s/%s', $this->client->buildPath($this->mount), $path);

--- a/src/SecretsEngines/AbstractSecretsEngine.php
+++ b/src/SecretsEngines/AbstractSecretsEngine.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Vault\SecretsEngines;
+
+use Vault\Client;
+use Vault\Exceptions\RuntimeException;
+
+/**
+ * Class AbstractSecretsEngine
+ *
+ * @package Vault\SecretsEngine
+ */
+abstract class AbstractSecretsEngine
+{
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    /**
+     * @var string
+     */
+    protected $mount;
+
+    public function __construct(Client $client, string $mount)
+    {
+        $this->client = $client;
+        if (empty($mount)) {
+            throw new RuntimeException('Secrets Engine require not-empty mount path');
+        }
+        if ($mount[0] !== '/') {
+            $mount = '/'.$mount;
+        }
+        $this->mount = $mount;
+    }
+
+    public function buildPath(string $path): string
+    {
+        return sprintf('%s/%s', $this->client->buildPath($this->mount), $path);
+    }
+
+    /**
+     * @return Client
+     */
+    public function getClient(): Client
+    {
+        return $this->client;
+    }
+
+    /**
+     * @param Client $client
+     *
+     * @return $this
+     */
+    public function setClient(Client $client): self
+    {
+        $this->client = $client;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMount(): string
+    {
+        return $this->mount;
+    }
+}

--- a/src/SecretsEngines/CubbyholeSecretsEngine.php
+++ b/src/SecretsEngines/CubbyholeSecretsEngine.php
@@ -13,6 +13,9 @@ use Vault\Client;
  */
 class CubbyholeSecretsEngine extends KeyValueVersion1SecretsEngine
 {
+    /**
+     * @param Client $client Authenticated Vault client
+     */
     public function __construct(Client $client)
     {
         parent::__construct(

--- a/src/SecretsEngines/CubbyholeSecretsEngine.php
+++ b/src/SecretsEngines/CubbyholeSecretsEngine.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Vault\SecretsEngines;
+
+use Vault\Client;
+
+/**
+ * Class CubbyholeSecretsEngine
+ *
+ * @link https://developer.hashicorp.com/vault/api-docs/secret/cubbyhole Cubbyhole Official Documentation
+ * 
+ * @package Vault\SecretsEngine
+ */
+class CubbyholeSecretsEngine extends KeyValueVersion1SecretsEngine
+{
+    public function __construct(Client $client)
+    {
+        parent::__construct(
+            $client,
+            '/cubbyhole'
+        );
+    }
+}

--- a/src/SecretsEngines/KeyValueVersion1SecretsEngine.php
+++ b/src/SecretsEngines/KeyValueVersion1SecretsEngine.php
@@ -2,6 +2,8 @@
 
 namespace Vault\SecretsEngines;
 
+use Vault\Builders\KeyValueVersion1\ListResponseBuilder;
+use Vault\ResponseModels\KeyValueVersion1\ListResponse;
 use Vault\ResponseModels\Response;
 
 /**
@@ -13,6 +15,12 @@ use Vault\ResponseModels\Response;
  */
 class KeyValueVersion1SecretsEngine extends AbstractSecretsEngine
 {
+    /**
+     * Read specified secret
+     * 
+     * @param string $path Path of the secret
+     * @return Response
+     **/
     public function read(string $path): Response
     {
         return $this->client->get(
@@ -20,13 +28,28 @@ class KeyValueVersion1SecretsEngine extends AbstractSecretsEngine
         );
     }
 
-    public function list(string $path): Response
+    /**
+     * List secrets at specified path
+     * 
+     * @param string $path Path to list secrets from
+     * @return ListResponse
+     **/
+    public function list(string $path): ListResponse
     {
-        return $this->client->list(
-            parent::buildPath($path)
+        return ListResponseBuilder::build(
+            $this->client->list(
+                parent::buildPath($path)
+            )
         );
     }
 
+    /**
+     * Create or update specified secret
+     * 
+     * @param string $path Path of the secret
+     * @param array $data Payload to write
+     * @return Response
+     **/
     public function createOrUpdate(string $path, array $data = []): Response
     {
         return $this->client->post(
@@ -35,6 +58,12 @@ class KeyValueVersion1SecretsEngine extends AbstractSecretsEngine
         );
     }
 
+    /**
+     * Delete secret
+     * 
+     * @param string $path Path of the secret
+     * @return Response
+     **/
     public function delete(string $path): Response
     {
         return $this->client->delete(

--- a/src/SecretsEngines/KeyValueVersion1SecretsEngine.php
+++ b/src/SecretsEngines/KeyValueVersion1SecretsEngine.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Vault\SecretsEngines;
+
+use Vault\ResponseModels\Response;
+
+/**
+ * Class KeyValueVersion1SecretsEngine
+ *
+ * @link https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1 Key/Value Version 1 Official Documentation
+ *
+ * @package Vault\SecretsEngine
+ */
+class KeyValueVersion1SecretsEngine extends AbstractSecretsEngine
+{
+    public function read(string $path): Response
+    {
+        return $this->client->get(
+            parent::buildPath($path)
+        );
+    }
+
+    public function list(string $path): Response
+    {
+        return $this->client->list(
+            parent::buildPath($path)
+        );
+    }
+
+    public function createOrUpdate(string $path, array $data = []): Response
+    {
+        return $this->client->post(
+            parent::buildPath($path),
+            json_encode($data)
+        );
+    }
+
+    public function delete(string $path): Response
+    {
+        return $this->client->delete(
+            parent::buildPath($path)
+        );
+    }
+}

--- a/src/SecretsEngines/KeyValueVersion2SecretsEngine.php
+++ b/src/SecretsEngines/KeyValueVersion2SecretsEngine.php
@@ -28,7 +28,7 @@ use Vault\ResponseModels\Response;
 class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
 {
     /**
-     * Configures secrets engine
+     * Configure secrets engine
      * 
      * @param Configuration $config Configuration to set
      * @return Response
@@ -42,7 +42,7 @@ class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
     }
 
     /**
-     * Reads current secrets engine configuration
+     * Read current secrets engine configuration
      * 
      * @return Configuration
      **/
@@ -74,7 +74,7 @@ class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
     }
 
     /**
-     * Creates new version of a secret
+     * Create new version of a secret
      * 
      * @param string $path Path of the secret
      * @param array $data Payload to write
@@ -98,7 +98,7 @@ class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
     }
 
     /**
-     * Patches existing secret
+     * Patch existing secret
      * 
      * @param string $path Path of the secret
      * @param array $data Payload to write
@@ -122,7 +122,7 @@ class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
     }
 
     /**
-     * Reads subkeys within a secret
+     * Read subkeys within a secret
      * 
      * @param string $path Path of the secret
      * @param int $version Version to read (0 = latest)
@@ -141,7 +141,7 @@ class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
     }
 
     /**
-     * Deletes latest version of the secret
+     * Delete latest version of the secret
      * 
      * @param string $path Path of the secret
      * @return Response
@@ -154,7 +154,7 @@ class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
     }
 
     /**
-     * Deletes specified secret versions
+     * Delete specified secret versions
      * 
      * @param string $path Path of the secret
      * @param int[] $versions Versions to delete
@@ -172,7 +172,7 @@ class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
     }
 
     /**
-     * Undeletes specified secret versions
+     * Undelete specified secret versions
      * 
      * @param string $path Path of the secret
      * @param int[] $versions Versions to delete
@@ -190,7 +190,7 @@ class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
     }
 
     /**
-     * Destroys (hard delete) specified secret versions
+     * Destroy (hard delete) specified secret versions
      * 
      * @param string $path Path of the secret
      * @param int[] $versions Versions to delete
@@ -223,7 +223,7 @@ class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
     }
 
     /**
-     * Reads specified secret metadata
+     * Read specified secret metadata
      * 
      * @param string $path Path of the secret
      * @return ReadMetadataResponse
@@ -238,7 +238,7 @@ class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
     }
 
     /**
-     * Creates or updates specified secret metadata
+     * Create or update specified secret metadata
      * 
      * @param string $path Path of the secret
      * @param SecretMetadata $metadata Metadata to set
@@ -253,7 +253,7 @@ class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
     }
 
     /**
-     * Patches specified secret metadata
+     * Patch specified secret metadata
      * 
      * @param string $path Path of the secret
      * @param array $metadata Metadata to set
@@ -268,7 +268,7 @@ class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
     }
 
     /**
-     * Deletes metadata and all versions
+     * Delete metadata and all versions
      * 
      * @param string $path Path of the secret
      * @return Response

--- a/src/SecretsEngines/KeyValueVersion2SecretsEngine.php
+++ b/src/SecretsEngines/KeyValueVersion2SecretsEngine.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Vault\SecretsEngines;
+
+use Vault\Builders\KeyValueVersion2\ListResponseBuilder;
+use Vault\Builders\KeyValueVersion2\ReadConfigurationResponseBuilder;
+use Vault\Builders\KeyValueVersion2\ReadMetadataResponseBuilder;
+use Vault\Builders\KeyValueVersion2\ReadResponseBuilder;
+use Vault\Builders\KeyValueVersion2\ReadSubkeysResponseBuilder;
+use Vault\Builders\KeyValueVersion2\VersionMetadataResponseBuilder;
+use Vault\Models\KeyValueVersion2\Configuration;
+use Vault\Models\KeyValueVersion2\SecretMetadata;
+use Vault\Models\KeyValueVersion2\WriteOptions;
+use Vault\ResponseModels\KeyValueVersion2\ListResponse;
+use Vault\ResponseModels\KeyValueVersion2\ReadMetadataResponse;
+use Vault\ResponseModels\KeyValueVersion2\ReadResponse;
+use Vault\ResponseModels\KeyValueVersion2\ReadSubkeysResponse;
+use Vault\ResponseModels\KeyValueVersion2\VersionMetadata;
+use Vault\ResponseModels\Response;
+
+/**
+ * Class KeyValueVersion2SecretsEngine
+ *
+ * @link https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2 Key/Value Version 2 Official Documentation
+ *
+ * @package Vault\SecretsEngine
+ */
+class KeyValueVersion2SecretsEngine extends AbstractSecretsEngine
+{
+    /**
+     * Configures secrets engine
+     * 
+     * @param Configuration $config Configuration to set
+     * @return Response
+     **/
+    public function configure(Configuration $config): Response
+    {
+        return $this->client->post(
+            parent::buildPath('config'),
+            json_encode($config)
+        );
+    }
+
+    /**
+     * Reads current secrets engine configuration
+     * 
+     * @return Configuration
+     **/
+    public function readConfiguration(): Configuration
+    {
+        return ReadConfigurationResponseBuilder::build(
+            $this->client->get(
+                parent::buildPath('config')
+            )
+        );
+    }
+
+    /**
+     * Read specified secret version
+     * 
+     * @param string $path Path of the secret
+     * @param int $version Version to read (0 = latest)
+     * @return ReadResponse
+     **/
+    public function read(string $path, int $version = 0): ReadResponse
+    {
+        return ReadResponseBuilder::build(
+            $this->client->get(
+                parent::buildPath(
+                    sprintf('data/%s?version=%d', $path, $version)
+                )
+            )
+        );
+    }
+
+    /**
+     * Creates new version of a secret
+     * 
+     * @param string $path Path of the secret
+     * @param array $data Payload to write
+     * @param WriteOptions|null $options Write options
+     * @return VersionMetadata
+     **/
+    public function createOrUpdate(string $path, array $data = [], ?WriteOptions $options = null): VersionMetadata
+    {
+        $payload = [
+            'data' => $data,
+        ];
+        if ($options) {
+            $payload['options'] = $options;
+        }
+        return VersionMetadataResponseBuilder::build(
+            $this->client->post(
+                parent::buildPath('data/'.$path),
+                json_encode($payload)
+            )
+        );
+    }
+
+    /**
+     * Patches existing secret
+     * 
+     * @param string $path Path of the secret
+     * @param array $data Payload to write
+     * @param WriteOptions|null $options Write options
+     * @return VersionMetadata
+     **/
+    public function patch(string $path, array $data = [], ?WriteOptions $options = null): VersionMetadata
+    {
+        $payload = [
+            'data' => $data,
+        ];
+        if ($options) {
+            $payload['options'] = $options;
+        }
+        return VersionMetadataResponseBuilder::build(
+            $this->client->patch(
+                parent::buildPath('data/'.$path),
+                json_encode($payload)
+            )
+        );
+    }
+
+    /**
+     * Reads subkeys within a secret
+     * 
+     * @param string $path Path of the secret
+     * @param int $version Version to read (0 = latest)
+     * @param int $depth Deepest nesting level (0 = no limit)
+     * @return ReadSubkeysResponse
+     **/
+    public function readSubkeys(string $path, int $version = 0, int $depth = 0): ReadSubkeysResponse
+    {
+        return ReadSubkeysResponseBuilder::build(
+            $this->client->get(
+                parent::buildPath(
+                    sprintf('subkeys/%s?version=%d&depth=%d', $path, $version, $depth)
+                )
+            )
+        );
+    }
+
+    /**
+     * Deletes latest version of the secret
+     * 
+     * @param string $path Path of the secret
+     * @return Response
+     **/
+    public function deleteLatest(string $path): Response
+    {
+        return $this->client->delete(
+            parent::buildPath('data/'.$path)
+        );
+    }
+
+    /**
+     * Deletes specified secret versions
+     * 
+     * @param string $path Path of the secret
+     * @param int[] $versions Versions to delete
+     * @return Response
+     **/
+    public function deleteVersions(string $path, array $versions = []): Response
+    {
+        $payload = [
+            'versions' => $versions
+        ];
+        return $this->client->post(
+            parent::buildPath('delete/'.$path),
+            json_encode($payload)
+        );
+    }
+
+    /**
+     * Undeletes specified secret versions
+     * 
+     * @param string $path Path of the secret
+     * @param int[] $versions Versions to delete
+     * @return Response
+     **/
+    public function undeleteVersions(string $path, array $versions = []): Response
+    {
+        $payload = [
+            'versions' => $versions
+        ];
+        return $this->client->post(
+            parent::buildPath('undelete/'.$path),
+            json_encode($payload)
+        );
+    }
+
+    /**
+     * Destroys (hard delete) specified secret versions
+     * 
+     * @param string $path Path of the secret
+     * @param int[] $versions Versions to delete
+     * @return Response
+     **/
+    public function destroyVersions(string $path, array $versions = []): Response
+    {
+        $payload = [
+            'versions' => $versions
+        ];
+        return $this->client->put(
+            parent::buildPath('destroy/'.$path),
+            json_encode($payload)
+        );
+    }
+
+    /**
+     * List secrets at specified path
+     * 
+     * @param string $path Path to list secrets from
+     * @return ListResponse
+     **/
+    public function list(string $path): ListResponse
+    {
+        return ListResponseBuilder::build(
+            $this->client->list(
+                parent::buildPath('metadata/'.$path)
+            )
+        );
+    }
+
+    /**
+     * Reads specified secret metadata
+     * 
+     * @param string $path Path of the secret
+     * @return ReadMetadataResponse
+     **/
+    public function readMetadata(string $path): ReadMetadataResponse
+    {
+        return ReadMetadataResponseBuilder::build(
+            $this->client->get(
+                parent::buildPath('metadata/'.$path)
+            )
+        );
+    }
+
+    /**
+     * Creates or updates specified secret metadata
+     * 
+     * @param string $path Path of the secret
+     * @param SecretMetadata $metadata Metadata to set
+     * @return Response
+     **/
+    public function createOrUpdateMetadata(string $path, SecretMetadata $metadata): Response
+    {
+        return $this->client->post(
+            parent::buildPath('metadata/'.$path),
+            json_encode($metadata)
+        );
+    }
+
+    /**
+     * Patches specified secret metadata
+     * 
+     * @param string $path Path of the secret
+     * @param array $metadata Metadata to set
+     * @return Response
+     **/
+    public function patchMetadata(string $path, array $metadata): Response
+    {
+        return $this->client->patch(
+            parent::buildPath('metadata/'.$path),
+            json_encode($metadata)
+        );
+    }
+
+    /**
+     * Deletes metadata and all versions
+     * 
+     * @param string $path Path of the secret
+     * @return Response
+     **/
+    public function deleteMetadata(string $path): Response
+    {
+        return $this->client->delete(
+            parent::buildPath('metadata/'.$path)
+        );
+    }
+}


### PR DESCRIPTION
Hello,

I'm suggesting adding another layer of abstraction based on Vault's own API docs - Secrets Engines (overlays).
They can be used to streamline path generation for specific jobs and objectify whole Vault transaction.
For example, in case of KeyValue Version 2:
- You won't longer have to remember which http method to use and which "keyword" to add in between mount and secret path
- Configuration, metadata, write options, etc. can now be standarized objects instead of associative arrays, so it's more clear what you can or cannot set
- Responses can now be more structurized (using builders), because such overlay can expect certain response structure from Vault

This PR:
- adds support for KV1 and KV2 with free Cubbyhole (as it is KV1 at predefined mount) secret engines
- fixes few small typos
- corrects Content-Type for PATCH method, as simple `application/json` may be rejected by newer Vault versions

I made sure it does NOT break backwards compability, so you can still use old way of raw calling client directly.
