### PR TITLE
Explicit nullable types

### DIFF
--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -83,7 +83,7 @@ abstract class BaseClient implements LoggerAwareInterface
         ClientInterface $client,
         RequestFactoryInterface $requestFactory,
         StreamFactoryInterface $streamFactory,
-        LoggerInterface $logger = null
+        ?LoggerInterface $logger = null
     ) {
         $this->baseUri = $baseUri;
         $this->client = $client;

--- a/src/Exceptions/RequestException.php
+++ b/src/Exceptions/RequestException.php
@@ -22,8 +22,8 @@ class RequestException extends Exception implements RequestExceptionInterface
     public function __construct(
         string $message = '',
         int $code = 0,
-        Throwable $previous = null,
-        RequestInterface $request = null
+        ?Throwable $previous = null,
+        ?RequestInterface $request = null
     ) {
         parent::__construct($message, $code, $previous);
 

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -61,7 +61,7 @@ class ClientTest extends Unit
      *
      * @return Client
      */
-    private function getClient(ClientInterface $client = null): Client
+    private function getClient(?ClientInterface $client = null): Client
     {
         return new Client(
             new Uri('http://127.0.0.1:8200'),


### PR DESCRIPTION
Resolves PHP 8.4 deprecation: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated